### PR TITLE
Always dispatch `login` event on submit

### DIFF
--- a/src/vaadin-login-mixin.html
+++ b/src/vaadin-login-mixin.html
@@ -16,6 +16,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
    * @memberof Vaadin
   */
   Vaadin.LoginMixin = subclass => class VaadinLoginMixin extends subclass {
+
+    /**
+     * Fired when user clicks on the "Forgot password" button
+     *
+     * @event forgot-password
+    */
+
+    /**
+     * Fired when an user submits the login.
+     * This event is fired **only** if `action` is `null`
+     *
+     * @event login
+     *
+    */
+
     static get properties() {
       return {
         /**

--- a/src/vaadin-login-mixin.html
+++ b/src/vaadin-login-mixin.html
@@ -18,14 +18,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
   Vaadin.LoginMixin = subclass => class VaadinLoginMixin extends subclass {
 
     /**
-     * Fired when user clicks on the "Forgot password" button
+     * Fired when user clicks on the "Forgot password" button.
      *
      * @event forgot-password
     */
 
     /**
      * Fired when an user submits the login.
-     * This event is fired **only** if `action` is `null`
+     * The event contains `username` and `password` values in the `detail` property.
      *
      * @event login
      *
@@ -34,9 +34,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     static get properties() {
       return {
         /**
-         * Defines how the login callback will be handled on a submit action:
-         * - If set, a synchronous POST call will be fired to the path defined.
-         * - If left blank, a `login` event will be dispatched containing `username` and `password`
+         * If set, a synchronous POST call will be fired to the path defined.
+         * The `login` event is also dispatched, so `event.preventDefault()` can be called to prevent the POST call.
         */
         action: {
           type: String,
@@ -44,7 +43,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           notify: true
         },
         /**
-         * If set, disable the "Log in" button and prevent user from submitting login form
+         * If set, disable the "Log in" button and prevent user from submitting login form.
          */
         disabled: {
           type: Boolean,

--- a/src/vaadin-login.html
+++ b/src/vaadin-login.html
@@ -149,17 +149,19 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
           this.error = false;
           this.disabled = true;
-          if (this.action == null) {
-            const eventDetails = {
-              bubbles: true,
-              cancelable: true,
-              detail: {
-                username: this.$.username.value,
-                password: this.$.password.value
-              }
-            };
-            this.dispatchEvent(new CustomEvent('login', eventDetails));
-          } else {
+
+          const loginEventDetails = {
+            bubbles: true,
+            cancelable: true,
+            detail: {
+              username: this.$.username.value,
+              password: this.$.password.value
+            }
+          };
+          const loginEvent = new CustomEvent('login', loginEventDetails);
+          this.dispatchEvent(loginEvent);
+
+          if (this.action && !loginEvent.defaultPrevented) {
             this.$.loginForm.submit();
           }
         }
@@ -185,20 +187,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         _isEnterKey(e) {
           return e.key === 'Enter' || e.keyCode === 13;
         }
-
-        /**
-         * Fired when user clicks on the "Forgot password" button
-         *
-         * @event forgot-password
-        */
-
-        /**
-         * Fired when an user submits the login.
-         * This event is fired **only** if `action` is `null`
-         *
-         * @event login
-         *
-        */
       }
 
       customElements.define(VaadinLogin.is, VaadinLogin);

--- a/test/login-test.html
+++ b/test/login-test.html
@@ -246,6 +246,24 @@
         expect(submitSpy.called).to.be.true;
       });
 
+      it('should not submit form if action is defined and event was default prevented', () => {
+        const {password} = fillUsernameAndPassword();
+        const {loginForm} = login.$;
+
+        // Remove `allow-redirect` to create an async call from iron-form
+        loginForm.removeAttribute('allow-redirect');
+
+        login.action = '/login';
+
+        login.addEventListener('login', e => e.preventDefault());
+
+        const submitSpy = sinon.spy(loginForm, 'submit');
+
+        MockInteractions.pressEnter(password);
+
+        expect(submitSpy.called).to.be.false;
+      });
+
       it('error should be hidden by default', () => {
         const errorPart = login.root.querySelectorAll('div[part="error-message"]')[0];
         expect(errorPart.offsetWidth).to.equal(0);


### PR DESCRIPTION
- Form will be submitted (with a POST call) only if both conditions are true:
  - `action` is defined
  - `login` event was not prevented by `CustomEvent#preventDefault()` call
  from a listener

Fix #39

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-login/43)
<!-- Reviewable:end -->
