### PR TITLE
Add a way to prevent auto enabling a component

### DIFF
--- a/src/vaadin-login-mixin.html
+++ b/src/vaadin-login-mixin.html
@@ -120,6 +120,14 @@ This program is available under Apache License Version 2.0, available at https:/
             };
           },
           notify: true
+        },
+
+        /**
+         * If set, prevents auto enabling the component when error property is set to true.
+         */
+        _preventAutoEnable: {
+          type: Boolean,
+          value: false
         }
       };
     }

--- a/src/vaadin-login.html
+++ b/src/vaadin-login.html
@@ -141,7 +141,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _errorChanged() {
-          if (this.error) {
+          if (this.error && !this._preventAutoEnable) {
             this.disabled = false;
           }
         }

--- a/test/login-test.html
+++ b/test/login-test.html
@@ -263,19 +263,29 @@
         expect(errorPart.offsetHeight).not.to.equal(0);
       });
 
-      it('should disable button when error is set to true', () => {
+      it('should enable button when error is set to true', () => {
         expect(login.error).to.be.false;
         login.setAttribute('disabled', 'disabled');
         expect(login.disabled).to.be.true;
         login.error = true;
         expect(login.disabled).to.be.false;
-      });
 
-      it('should re-enable button when error is set from true to false', () => {
-        login.error = true;
         login.error = false;
         expect(login.error).to.be.false;
         expect(login.disabled).to.be.false;
+      });
+
+      it('should not enable button when error is set to true and _preventAutoEnable', () => {
+        expect(login.error).to.be.false;
+        login.disabled = true;
+        login._preventAutoEnable = true;
+        expect(login.disabled).to.be.true;
+        login.error = true;
+        expect(login.disabled).to.be.true;
+
+        login.error = false;
+        expect(login.error).to.be.false;
+        expect(login.disabled).to.be.true;
       });
 
     });


### PR DESCRIPTION
Flow integration has to replicate the auto enable logic itself, in order to provide a way of keeping the component disabled after bad submission (too many failed attempts). Related #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-login/79)
<!-- Reviewable:end -->
