### PR TITLE
Remove material-color-light from included style list

### DIFF
--- a/theme/material/vaadin-login-form-wrapper-styles.html
+++ b/theme/material/vaadin-login-form-wrapper-styles.html
@@ -1,6 +1,6 @@
 <dom-module id="material-login-form-wrapper" theme-for="vaadin-login-form-wrapper">
   <template>
-    <style include="material-color-light material-typography">
+    <style include="material-typography">
       :host {
         background: var(--material-background-color) linear-gradient(hsla(0, 0%, 100%, 0.3), hsla(0, 0%, 100%, 0.3));
         min-height: 250px;

--- a/theme/material/vaadin-login-overlay-styles.html
+++ b/theme/material/vaadin-login-overlay-styles.html
@@ -5,7 +5,7 @@
 
 <dom-module id="vaadin-login-overlay-wrapper-material-styles" theme-for="vaadin-login-overlay-wrapper">
   <template>
-    <style include="material-overlay material-color-light material-typography">
+    <style include="material-overlay material-typography">
       :host {
         top: 0;
         right: 0;
@@ -210,7 +210,7 @@
         }
 
         [part="brand"] h1 {
-          font-size: 2.5rem;
+          font-size: 2.5em;
         }
 
         [part="form"] {
@@ -273,7 +273,7 @@
 
 <dom-module id="material-login-overlay" theme-for="vaadin-login-form-wrapper">
   <template>
-    <style include="material-color-light material-typography">
+    <style include="material-typography">
       :host([theme~="with-overlay"]) {
         display: flex;
         justify-content: center;
@@ -286,7 +286,7 @@
 
       :host([theme~="with-overlay"]) [part="form"] h2 {
         text-align: center;
-        font-size: 1.8rem;
+        font-size: 1.8em;
         font-weight: 500;
       }
 


### PR DESCRIPTION
This causes the color definition to be placed inside element's shadow root, preventing the user from changing CSS properties values from the body level.

Also change from `rem` to `em` in size definition so it will react to changes in the body level.

Fixes #89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-login/92)
<!-- Reviewable:end -->
