### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,13 @@
+export interface LoginI18n {
+  form: {
+    title: string;
+    username: string;
+    password: string;
+    submit: string;
+    forgotPassword: string;
+  };
+  errorMessage: {
+    title: string;
+    message: string;
+  };
+}

--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -10,4 +10,9 @@ export interface LoginI18n {
     title: string;
     message: string;
   };
+  header?: {
+    title?: string;
+    description?: string;
+  };
+  additionalInformation?: string;
 }

--- a/bower.json
+++ b/bower.json
@@ -28,13 +28,13 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.1",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.6.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.4.0"
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0-alpha1",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.5.0"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
@@ -42,8 +42,8 @@
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "iron-test-helpers": "^2.0.0",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.0.0",
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0",
     "vaadin-icons": "vaadin/vaadin-icons#^4.2.1",
-    "vaadin-dialog": "^2.2.0"
+    "vaadin-dialog": "^2.5.0-alpha1"
   }
 }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,19 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "src/vaadin-login-form-wrapper.js",
+    "src/vaadin-login-overlay-wrapper.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "LoginI18n"
+    ],
+    "@polymer/polymer/interfaces": [
+      "StampedTemplate"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,16 @@
+module.exports = {
+  files: [
+    'src/vaadin-login-form.js',
+    'src/vaadin-login-overlay.js',
+    'vaadin-login-form.js',
+    'vaadin-login-overlay.js'
+  ],
+  from: [
+    /@mixes Vaadin\.Login\./g,
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    '@mixes ',
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/src/vaadin-login-form.html
+++ b/src/vaadin-login-form.html
@@ -66,27 +66,22 @@
         static get is() {
           return 'vaadin-login-form';
         }
+
         static get version() {
           return '1.1.0';
         }
 
-        static get properties() {
-          return {
-            /**
-             * Defines the theme of the element.
-             * The value is propagated to vaadin-login-form-wrapper element.
-             */
-            theme: {
-              type: String
-            }
-          };
-        }
-
+        /** @protected */
         connectedCallback() {
           super.connectedCallback();
           this._handleInputKeydown = this._handleInputKeydown.bind(this);
         }
 
+        /**
+         * @param {StampedTemplate} dom
+         * @return {null}
+         * @protected
+         */
         _attachDom(dom) {
           this.appendChild(dom);
         }
@@ -97,6 +92,7 @@
           ];
         }
 
+        /** @private */
         _errorChanged() {
           if (this.error && !this._preventAutoEnable) {
             this.disabled = false;
@@ -126,14 +122,17 @@
           }
         }
 
+        /** @private */
         __isValid(input) {
           return (input.validate && input.validate()) || (input.checkValidity && input.checkValidity());
         }
 
+        /** @private */
         _isEnterKey(e) {
           return e.key === 'Enter' || e.keyCode === 13;
         }
 
+        /** @private */
         _handleInputKeydown(e) {
           if (this._isEnterKey(e)) {
             const {currentTarget: inputActive} = e;
@@ -149,6 +148,7 @@
           }
         }
 
+        /** @private */
         _handleInputKeyup(e) {
           const isTab = e.key === 'Tab' || e.keyCode === 9;
           const input = e.currentTarget;

--- a/src/vaadin-login-mixin.html
+++ b/src/vaadin-login-mixin.html
@@ -15,14 +15,14 @@ This program is available under Apache License Version 2.0, available at https:/
   /**
    * @polymerMixin
    * @memberof Vaadin.Login
-  */
+   */
   Vaadin.Login.LoginMixin = superClass => class LoginMixin extends superClass {
 
     /**
      * Fired when user clicks on the "Forgot password" button.
      *
      * @event forgot-password
-    */
+     */
 
     /**
      * Fired when an user submits the login.
@@ -30,32 +30,37 @@ This program is available under Apache License Version 2.0, available at https:/
      *
      * @event login
      *
-    */
+     */
 
     static get properties() {
       return {
         /**
          * If set, a synchronous POST call will be fired to the path defined.
          * The `login` event is also dispatched, so `event.preventDefault()` can be called to prevent the POST call.
+         * @type {string | null}
         */
         action: {
           type: String,
           value: null,
           notify: true
         },
+
         /**
          * If set, disable the "Log in" button and prevent user from submitting login form.
          * It is re-enabled automatically, when error is set to true, allowing form resubmission
          * after user makes changes.
+         * @type {boolean}
          */
         disabled: {
           type: Boolean,
           value: false,
           notify: true
         },
+
         /**
          * If set, the error message is shown. The message is hidden by default.
          * When set, it changes the disabled state of the submit button.
+         * @type {boolean}
          */
         error: {
           type: Boolean,
@@ -63,8 +68,10 @@ This program is available under Apache License Version 2.0, available at https:/
           reflectToAttribute: true,
           notify: true
         },
+
         /**
          * Whether to hide the forgot password button. The button is visible by default.
+         * @type {boolean}
          */
         noForgotPassword: {
           type: Boolean,
@@ -99,7 +106,7 @@ This program is available under Apache License Version 2.0, available at https:/
             },
             additionalInformation: 'In case you need to provide some additional info for the user.'
           }
-         *
+         * @type {!LoginI18n}
          * @default {English/US}
          */
         i18n: {
@@ -124,6 +131,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * If set, prevents auto enabling the component when error property is set to true.
+         * @private
          */
         _preventAutoEnable: {
           type: Boolean,
@@ -132,6 +140,10 @@ This program is available under Apache License Version 2.0, available at https:/
       };
     }
 
+    /**
+     * @param {!Event} e
+     * @protected
+     */
     _retargetEvent(e) {
       e.stopPropagation();
       const {

--- a/src/vaadin-login-overlay.html
+++ b/src/vaadin-login-overlay.html
@@ -73,33 +73,31 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Defines the application description
+             * @type {string}
              */
             description: {
               type: String,
               value: 'Application description',
               notify: true
             },
+
             /**
              * True if the overlay is currently displayed.
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
               value: false,
               observer: '_onOpenedChange'
             },
+
             /**
              * Defines the application title
+             * @type {string}
              */
             title: {
               type: String,
               value: 'App name'
-            },
-            /**
-             * Defines the theme of the element.
-             * The value is propagated to vaadin-login-overlay-wrapper element.
-             */
-            theme: {
-              type: String
             }
           };
         }
@@ -110,12 +108,14 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
           this._preventClosingLogin = this._preventClosingLogin.bind(this);
         }
 
+        /** @protected */
         connectedCallback() {
           super.connectedCallback();
 
@@ -123,6 +123,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.vaadinLoginOverlayWrapper.addEventListener('vaadin-overlay-escape-press', this._preventClosingLogin);
         }
 
+        /** @protected */
         disconnectedCallback() {
           super.disconnectedCallback();
 
@@ -131,6 +132,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.vaadinLoginOverlayWrapper.opened = false;
         }
 
+        /** @private */
         __i18nChanged(i18n) {
           const header = i18n.base;
           if (!header) {
@@ -140,10 +142,12 @@ This program is available under Apache License Version 2.0, available at https:/
           this.description = header.description;
         }
 
+        /** @private */
         _preventClosingLogin(e) {
           e.preventDefault();
         }
 
+        /** @private */
         _onOpenedChange() {
           if (!this.opened) {
 
@@ -164,6 +168,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _teleport(elements) {
           const teleported = Array.from(elements).map(e => {
             return this.$.vaadinLoginOverlayWrapper.appendChild(e);
@@ -176,6 +181,7 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /** @private */
         _getElementsToTeleport() {
           return this.querySelectorAll('[slot=title]');
         }


### PR DESCRIPTION
Fixes #102 

Generated TS definitions look like this:

### `vaadin-login-form.d.ts`

```ts
import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {LoginMixin} from './vaadin-login-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {PolymerElement} from '@polymer/polymer/polymer-element.js';

declare class LoginFormElement extends
  ElementMixin(
  ThemableMixin(
  LoginMixin(
  PolymerElement))) {
  connectedCallback(): void;
  _attachDom(dom: StampedTemplate|null): null;
  submit(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-login-form": LoginFormElement;
  }
}

export {LoginFormElement};

import {StampedTemplate} from '@polymer/polymer/interfaces';
```

### `vaadin-login-mixin.d.ts`

```ts
export {LoginMixin};

declare function LoginMixin<T extends new (...args: any[]) => {}>(base: T): T & LoginMixinConstructor;

interface LoginMixinConstructor {
  new(...args: any[]): LoginMixin;
}

export {LoginMixinConstructor};

interface LoginMixin {
  action: string|null;
  disabled: boolean;
  error: boolean;
  noForgotPassword: boolean;
  i18n: LoginI18n;
  _retargetEvent(e: Event): void;
}

import {LoginI18n} from '../@types/interfaces';
```

### `vaadin-login-overlay.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {LoginMixin} from './vaadin-login-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class LoginOverlayElement extends
  ElementMixin(
  ThemableMixin(
  LoginMixin(
  PolymerElement))) {
  description: string;
  opened: boolean;
  title: string;
  ready(): void;
  connectedCallback(): void;
  disconnectedCallback(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-login-overlay": LoginOverlayElement;
  }
}

export {LoginOverlayElement};
```